### PR TITLE
feat: add random play for Suno playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ micli play_list test.txt # play the list
 micli suno 
 ```
 
+## -> 播放 suno.ai trending random
+
+```
+micli suno_random
+```
+
 ## Install
 ```
 pip3 install -U miservice_fork

--- a/miservice/cli.py
+++ b/miservice/cli.py
@@ -115,8 +115,8 @@ async def main(args):
                 "loop",
                 "play_list",
                 "suno",
-                "suno_random"
-                ]:
+                "suno_random",
+            ]:
                 arg = args.split(" ")[0].strip()
                 result = await mina_service.device_list()
                 if not env.get("MI_DID"):
@@ -130,11 +130,13 @@ async def main(args):
                         await mina_service.player_pause(device_id)
                     elif "suno" in args_list[0]:
                         song_dict = await get_suno_playlist()
-                        print("Will play suno trending list")
                         print(song_dict)
                         song_urls = list(song_dict.keys())
                         if args_list[0] == "suno_random":
                             random.shuffle(song_urls)
+                            print("Will play suno trending list randomly")
+                        else:
+                            print("Will play suno trending list")
                         for song_url in song_urls:
                             title = song_dict[song_url]
                             print(f"Will play {song_url.strip()} title {title}")

--- a/miservice/cli.py
+++ b/miservice/cli.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 import tempfile
+import random
 from pathlib import Path
 
 import aiohttp
@@ -114,7 +115,8 @@ async def main(args):
                 "loop",
                 "play_list",
                 "suno",
-            ]:
+                "suno_random"
+                ]:
                 arg = args.split(" ")[0].strip()
                 result = await mina_service.device_list()
                 if not env.get("MI_DID"):
@@ -126,18 +128,22 @@ async def main(args):
                 if len(args_list) == 1:
                     if args_list[0] == "pause":
                         await mina_service.player_pause(device_id)
-                    elif args_list[0] == "suno":
+                    elif "suno" in args_list[0]:
                         song_dict = await get_suno_playlist()
                         print("Will play suno trending list")
                         print(song_dict)
-                        for song_url, title in song_dict.items():
+                        song_urls = list(song_dict.keys())
+                        if args_list[0] == "suno_random":
+                            random.shuffle(song_urls)
+                        for song_url in song_urls:
+                            title = song_dict[song_url]
                             print(f"Will play {song_url.strip()} title {title}")
                             await mina_service.play_by_url(device_id, song_url.strip())
                             duration = await _get_duration(song_url)
                             await asyncio.sleep(duration)
                         await mina_service.player_pause(device_id)
                     else:
-                        print("Please provice play url")
+                        print("Please provide a play URL")
                     return
                 # make device_id
                 if arg == "loop":

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup
 setup(
     name="miservice_fork",
     description="XiaoMi Cloud Service fork from https://github.com/Yonsm/MiService",
-    version="2.4.0",
+    version="2.4.1",
     license="MIT",
     author="Yonsm, yihong0618",
     author_email="Yonsm@qq.com, zouzou0208@gmail.com",


### PR DESCRIPTION
This pull request introduces a new feature allowing users to play songs from the Suno playlist in a random order. 

By running `micli suno_random`, users can enjoy a more varied music experience, reducing the repetitiveness of playing the playlist from the start to end each time. 

Looking forward to bringing a bit of surprise to the user experience~