### PR TITLE
fixbug  DID比较错误

### DIFF
--- a/miservice/miioservice.py
+++ b/miservice/miioservice.py
@@ -109,7 +109,7 @@ class MiIOService:
                     "token": i["token"],
                 }
                 for i in result
-                if not name or name in i["name"]
+                if not name or name in i["did"]
             ]
         )
 


### PR DESCRIPTION
miioservice.py->device_list传入did,使用的变量名是name
所以应该是name和result的did比
 return (
            result
            if name == "full"
            else [
                {
                    "name": i["name"],
                    "model": i["model"],
                    "did": i["did"],
                    "token": i["token"],
                }
                for i in result
                # if not name or name in i["name"]
                if not name or name in i["did"]
            ]
        )